### PR TITLE
Change mytesla app docker compose to host

### DIFF
--- a/apps/mytesla/2.0.0/data.yml
+++ b/apps/mytesla/2.0.0/data.yml
@@ -168,3 +168,23 @@ additionalProperties:
         en: Optional. Required when using Baidu Map AK for location services.
         zh: 可选配置。使用百度地图 AK 时需要配置。
         zh-Hant: 可選配置。使用百度地圖 AK 時需要配置。
+
+    - default: ""
+      envKey: PANEL_PORT
+      edit: false
+      label:
+        en: Panel Port
+        zh: 面板端口
+        zh-Hant: 面板端口
+      required: false
+      type: text
+
+    - default: ""
+      envKey: PANEL_NO
+      edit: false
+      label:
+        en: Panel Number
+        zh: 面板编号
+        zh-Hant: 面板編號
+      required: false
+      type: text

--- a/apps/mytesla/2.0.0/docker-compose.yml
+++ b/apps/mytesla/2.0.0/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     container_name: ${CONTAINER_NAME}-cloudflared
     restart: unless-stopped
     command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN}
+    network_mode: host
     depends_on:
       - traefik
 
@@ -14,6 +15,7 @@ services:
     image: docker.1ms.run/httpd:2.4
     container_name: ${CONTAINER_NAME}-auth-generator
     restart: "unless-stopped"
+    network_mode: host
     volumes:
       - ./data/auth:/auth
     environment:
@@ -36,14 +38,13 @@ services:
     image: docker.1ms.run/traefik:v3.5.0
     container_name: ${CONTAINER_NAME}-traefik
     restart: unless-stopped
+    network_mode: host
     command:
       - --api.insecure=true
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
-      - --entrypoints.web.address=:80
+      - --entrypoints.web.address=:${TRAEFIK_HTTP_PORT:-80}
       - --log.level=INFO
-    ports:
-      - "${TRAEFIK_HTTP_PORT:-80}:80"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./data/auth:/auth
@@ -56,6 +57,7 @@ services:
     image: docker.1ms.run/gococonut/teslamate
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
+    network_mode: host
     depends_on:
       - database
       - mosquitto
@@ -63,8 +65,8 @@ services:
       - DATABASE_USER=${TM_DB_USER}
       - DATABASE_PASS=${TM_DB_PASS}
       - DATABASE_NAME=${TM_DB_NAME}
-      - DATABASE_HOST=database
-      - MQTT_HOST=mosquitto
+      - DATABASE_HOST=localhost
+      - MQTT_HOST=localhost
       - VIRTUAL_HOST=${CLOUDFLARE_DOMAIN}
       - ENCRYPTION_KEY=${TM_ENCRYPTION_KEY}
       - TZ=${TZ}
@@ -91,13 +93,14 @@ services:
     image: docker.1ms.run/gococonut/grafana
     container_name: ${CONTAINER_NAME}-grafana
     restart: unless-stopped
+    network_mode: host
     depends_on:
       - database
     environment:
       - DATABASE_USER=${TM_DB_USER}
       - DATABASE_PASS=${TM_DB_PASS}
       - DATABASE_NAME=${TM_DB_NAME}
-      - DATABASE_HOST=database
+      - DATABASE_HOST=localhost
       - GRAFANA_PASSWD=${GRAFANA_PW}
       - GF_SECURITY_ADMIN_USER=${GRAFANA_USER}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PW}
@@ -118,16 +121,19 @@ services:
     image: docker.1ms.run/mytesla/teslamateapi:latest
     container_name: ${CONTAINER_NAME}-teslamateapi
     restart: unless-stopped
+    network_mode: host
     depends_on:
       - database
     environment:
       - DATABASE_USER=${TM_DB_USER}
       - DATABASE_PASS=${TM_DB_PASS}
       - DATABASE_NAME=${TM_DB_NAME}
-      - DATABASE_HOST=database
+      - DATABASE_HOST=localhost
       - ENCRYPTION_KEY=${TM_ENCRYPTION_KEY}
-      - MQTT_HOST=mosquitto
+      - MQTT_HOST=localhost
       - API_TOKEN=${API_TOKEN}
+      - PANEL_PORT=${PANEL_PORT}
+      - PANEL_NO=${PANEL_NO}
     volumes:
       - ./data/teslamateapi:/opt/app/data
     labels:
@@ -140,6 +146,7 @@ services:
     image: docker.1ms.run/postgres:17
     container_name: ${CONTAINER_NAME}-database
     restart: unless-stopped
+    network_mode: host
     environment:
       - POSTGRES_USER=${TM_DB_USER}
       - POSTGRES_PASSWORD=${TM_DB_PASS}
@@ -151,11 +158,8 @@ services:
     image: docker.1ms.run/eclipse-mosquitto:2
     container_name: ${CONTAINER_NAME}-mosquitto
     restart: unless-stopped
+    network_mode: host
     command: mosquitto -c /mosquitto-no-auth.conf
     volumes:
       - ./data/mosquitto/config:/mosquitto/config
       - ./data/mosquitto/data:/mosquitto/data
-
-networks:
-  default:
-    name: ${CONTAINER_NAME}-network


### PR DESCRIPTION
Configure MyTesla app to use Docker host network mode and add non-modifiable `PANEL_PORT` and `PANEL_NO` environment variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-74901930-fdcf-4982-a836-5db063193cf6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74901930-fdcf-4982-a836-5db063193cf6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

